### PR TITLE
Added PHPUnit 6 support for symfony-cmf/testing

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -253,11 +253,11 @@ resource:
       php: ['7.1', '7.2']
       make_tasks:
         unit_tests: ~
+
 testing:
   description: |
     **NOTE**: This is an internal tool and is not intended to be used outside of
     the context of the CMF.
-
   branches:
     master:
       minimum_stability: dev
@@ -267,7 +267,9 @@ testing:
       make_tasks:
         unit_tests: ~
       versions:
-        symfony: ['2.8.*', '3.3.*', '3.4.*', '4.0.*']
+        symfony: ['^2.8.18', '3.3.*', '3.4.*', '4.0.*']
+      phpunit_version: '6.5'
+
 tree-browser-bundle:
   excluded_files:
       - .travis.yml.twig


### PR DESCRIPTION
Applied changes from the PR symfony-cmf/testing#168 in order to use PHPUnit 6.