### PR TITLE
Support for PHP >= 5.6 for symfony-cmf/testing

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -264,7 +264,7 @@ testing:
       minimum_stability: dev
       docs_path: 'components/testing'
       deprecation_warnings: "/.*each.*/"
-      php: ['7.1', '7.2']
+      php: ['5.6','7.0','7.1', '7.2']
       make_tasks:
         unit_tests: ~
       versions:

--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -51,7 +51,7 @@ matrix:
     - php: {{ php|last }}
       env: {% if minimum_stability != 'prod' %}STABILITY={{ minimum_stability }}{%  endif  %} SYMFONY_VERSION={{ versions.symfony|last }}
     - php: {{ php|first }}
-      env: {% if minimum_stability != 'prod' %}STABILITY={{ minimum_stability }}{%  endif  %} COMPOSER_FLAGS="--prefer-lowest" SYMFONY_VERSION={{ versions.symfony|first }} SYMFONY_DEPRECATIONS_HELPER=weak
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_VERSION={{ versions.symfony|first }} SYMFONY_DEPRECATIONS_HELPER=weak
 {% if php|length < 3 %}
 {% for version in versions.symfony if version != versions.symfony|first and version != versions.symfony|last %}
     - php: {{ php|last }}


### PR DESCRIPTION
This PR provides support for PHP 5.6 and PHP 7.0 again for `symfony-cmf/testing` package (to accept and merge https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/521)

See my another PR https://github.com/symfony-cmf/testing/pull/181, i updated `.travis.yml` file there to test `symfony-cmf/testing` package against PHP>=5.6 and Symfony>=2.8

Also, this PR solves `composer and out or memory` issues: jobs with `--prefer-lowest` composer flag will always require stable packages (with default minimum-stability option). Without it such jobs require too much memory to `compose update` operation with php 5.6